### PR TITLE
Implement mission join

### DIFF
--- a/src/app/missions/missionsSlice.js
+++ b/src/app/missions/missionsSlice.js
@@ -1,28 +1,45 @@
-import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import axios from "axios";
 
 const initialState = {
   missions: [],
 };
 
-const url = 'https://api.spacexdata.com/v3/missions';
+const url = "https://api.spacexdata.com/v3/missions";
 
-export const fetchMissions = createAsyncThunk('missions/fetchMissions', async () => {
-  const res = await fetch(url);
-  const data = await res.json();
-  return data;
-});
+export const fetchMissions = createAsyncThunk(
+  "missions/fetchMissions",
+  async () => {
+    const res = await axios.get(url);
+    return res.data;
+  }
+);
 
 export const missionsSlice = createSlice({
-  name: 'missions',
+  name: "missions",
   initialState,
-  reducers: {},
+  reducers: {
+    joinMissions: (state, action) => {
+      const newState = JSON.parse(JSON.stringify(state)).missions.map(
+        (mission) => {
+          if (mission.mission_id !== action.payload) {
+            return mission;
+          } else {
+            return { ...mission, reserved: true };
+          }
+        }
+      );
+      return {...JSON.parse(JSON.stringify(state)), missions : newState };
+    },
+  },
   extraReducers: (builder) => {
-    builder.addCase(fetchMissions.fulfilled, (state, action) => {
-      state.missions = action.payload;
-    });
+    builder.addCase(fetchMissions.fulfilled, (state, action) =>({
+      ...state,
+      missions : action.payload
+    }));
   },
 });
 
-export const { increment } = missionsSlice.actions;
+export const { joinMissions } = missionsSlice.actions;
 
 export default missionsSlice.reducer;

--- a/src/components/Missions.js
+++ b/src/components/Missions.js
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { fetchMissions } from "../app/missions/missionsSlice";
+import { fetchMissions, joinMissions } from "../app/missions/missionsSlice";
 import RenderMissions from "./RenderMissions";
 
 function Missions() {
@@ -9,12 +9,16 @@ function Missions() {
 
   useEffect(() => {
     dispatch(fetchMissions());
-  }, []);
+  }, [dispatch]);
+
+  const handleJoin = (id) => {
+    dispatch(joinMissions(id))
+  }
 
   return (
     <div>
       {missions.map((mission) => (
-        <RenderMissions key={mission.mission_id} mission={mission} />
+        <RenderMissions key={mission.mission_id} mission={mission} handleJoin={handleJoin}/>
       ))}
     </div>
   );

--- a/src/components/RenderMissions.js
+++ b/src/components/RenderMissions.js
@@ -1,11 +1,12 @@
 import React from 'react';
 
-function RenderMissions({mission}) {
+function RenderMissions({mission, handleJoin}) {
     const {mission_id, mission_name} = mission
   return (
     <div>
         id:{mission_id} |
         mission name: {mission_name}
+        <button type='button' onClick={()=> handleJoin(mission_id)}>Join Mission</button>
     </div>
   )
 }


### PR DESCRIPTION
- [x] When a user clicks the "Join Mission" button, action needs to be dispatched to update the store. You need to get the ID of the selected mission and update the state. Remember you mustn't mutate the state. Instead, you need to return a new state object with all missions, but the selected mission will have an extra key reserved with its value set to true. You could use a JS filter() or map() to set the value of the new state 